### PR TITLE
修复部分错误配置和设置Module时的错误

### DIFF
--- a/application/config.php
+++ b/application/config.php
@@ -27,7 +27,7 @@ return [
     'action_suffix'       => '',
     'file_ext'            => '.php',
     'url_model'           => 1,
-    'TMPL_EXCEPTION_FILE' => THINK_PATH.'tpl/think_exception.tpl',// 异常页面的模板文件
+    'exception_tmpl'      => THINK_PATH.'tpl/think_exception.tpl',// 异常页面的模板文件
     'show_page_trace'     => true,
     'trace_page_tabs'     => array('BASE'=>'基本','FILE'=>'文件','INFO'=>'流程','ERR|NOTIC'=>'错误','SQL'=>'SQL','DEBUG'=>'调试'), // 页面Trace可定制的选项卡 
     'db_sql_log'          => true,

--- a/thinkphp/convention.php
+++ b/thinkphp/convention.php
@@ -25,7 +25,7 @@ return [
     'default_jsonp_handler' =>  'jsonpReturn', // 默认JSONP格式返回的处理方法
     'var_jsonp_handler'     =>  'callback',
     'template_engine'       =>  'think',
-    'common_module'         =>  'Common',
+    'common_module'         =>  'common',
     'action_bind_class'     =>  false,
     'url_module_map'        =>  [],
 

--- a/thinkphp/library/think/app.php
+++ b/thinkphp/library/think/app.php
@@ -237,6 +237,8 @@ class App {
                 if($config['require_module'] && !isset($_GET[$config['var_module']])) {
                     $_GET[$config['var_module']]     = array_shift($paths);
                     $_SERVER['PATH_INFO'] = implode('/', $paths);
+                }else if($config['require_module'] == false && !isset($_GET[$config['var_module']])){
+                    $_GET[$config['var_module']] = $config['default_module'];
                 }
             }
             // 去除URL后缀


### PR DESCRIPTION
文档中 
'require_module'=>false, // 设置不显示URL中的模块，但必须设置下面的default_module参数
'default_module'=>'Index', // 设置应用的默认模块


require_module = false 时 未使用default_module