### PR TITLE
新增Base64编(解)码驱动，修正Org命名空间

### DIFF
--- a/thinkphp/library/org/auto.php
+++ b/thinkphp/library/org/auto.php
@@ -9,7 +9,7 @@
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
 
-namespace think;
+namespace org;
 
 class Auto
 {

--- a/thinkphp/library/org/crypt.php
+++ b/thinkphp/library/org/crypt.php
@@ -9,7 +9,7 @@
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
 
-namespace think;
+namespace org;
 
 class Crypt
 {

--- a/thinkphp/library/org/image.php
+++ b/thinkphp/library/org/image.php
@@ -9,7 +9,7 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think;
+namespace org;
 
 /* 缩略图相关常量定义 */
 define('THINKIMAGE_THUMB_SCALING', 1); //常量，标识缩略图等比例缩放类型

--- a/thinkphp/library/org/image/driver/gd.php
+++ b/thinkphp/library/org/image/driver/gd.php
@@ -9,7 +9,7 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\image\driver;
+namespace org\image\driver;
 
 use Exception;
 
@@ -17,21 +17,26 @@ class Gd
 {
     /**
      * 图像资源对象
+     * 
      * @var resource
      */
     private $im;
+
     /**
-     * @var $git \think\image\driver\Gif
-*/
+     * @var $git org\image\driver\Gif
+     */
     private $gif;
+
     /**
-     * 图像信息，包括width,height,type,mime,size
+     * 图像信息，包括 width, height, type, mime, size
+     * 
      * @var array
      */
     private $info;
 
     /**
      * 构造方法，可用于打开一张图像
+     * 
      * @param string $imgname 图像路径
      */
     public function __construct($imgname = null)
@@ -322,8 +327,8 @@ class Gd
                 //设置缩略图的坐标及宽度和高度
                 $neww = $w * $scale;
                 $newh = $h * $scale;
-                $x = $this->info['width'] - $w;
-                $y = $this->info['height'] - $h;
+                $x    = $this->info['width'] - $w;
+                $y    = $this->info['height'] - $h;
                 $posx = ($width - $w * $scale) / 2;
                 $posy = ($height - $h * $scale) / 2;
 

--- a/thinkphp/library/org/image/driver/gif.php
+++ b/thinkphp/library/org/image/driver/gif.php
@@ -9,23 +9,27 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\image\driver;
+namespace org\image\driver;
+
 class Gif
 {
     /**
      * GIF帧列表
+     *
      * @var array
      */
     private $frames = [];
 
     /**
      * 每帧等待时间列表
+     *
      * @var array
      */
     private $delays = [];
 
     /**
      * 构造方法，用于解码GIF图片
+     *
      * @param string $src GIF图片数据
      * @param string $mod 图片数据类型
      */
@@ -49,6 +53,7 @@ class Gif
 
     /**
      * 设置或获取当前帧的数据
+     * 
      * @param  string $stream 二进制数据流
      * @return mixed        获取到的数据
      */
@@ -57,13 +62,13 @@ class Gif
         if (is_null($stream)) {
             $current = current($this->frames);
             return false === $current ? reset($this->frames) : $current;
-        } else {
-            $this->frames[key($this->frames)] = $stream;
         }
+        $this->frames[key($this->frames)] = $stream;
     }
 
     /**
      * 将当前帧移动到下一帧
+     * 
      * @return string 当前帧数据
      */
     public function nextImage()
@@ -73,6 +78,7 @@ class Gif
 
     /**
      * 编码并保存当前GIF图片
+     * 
      * @param  string $gifname 图片名称
      */
     public function save($gifname)
@@ -141,7 +147,7 @@ class GIFEncode
         $this->LOP = ($GIF_lop > -1) ? $GIF_lop : 0;
         $this->DIS = ($GIF_dis > -1) ? (($GIF_dis < 3) ? $GIF_dis : 3) : 2;
         $this->COL = ($GIF_red > -1 && $GIF_grn > -1 && $GIF_blu > -1) ?
-            ($GIF_red | ($GIF_grn << 8) | ($GIF_blu << 16)) : -1;
+        ($GIF_red | ($GIF_grn << 8) | ($GIF_blu << 16)) : -1;
 
         for ($i = 0; $i < count($GIF_src); $i++) {
             if (strToLower($GIF_mod) == "url") {
@@ -158,15 +164,15 @@ class GIFEncode
             }
             for ($j = (13 + 3 * (2 << (ord($this->BUF[$i]{10}) & 0x07))), $k = true; $k; $j++) {
                 switch ($this->BUF[$i]{ $j}) {
-                    case "!":
-                        if ((substr($this->BUF[$i], ($j + 3), 8)) == "NETSCAPE") {
-                            printf("%s: %s ( %s source )!", $this->VER, $this->ERR['ERR03'], ($i + 1));
-                            exit(0);
-                        }
-                        break;
-                    case ";":
-                        $k = false;
-                        break;
+                case "!":
+                    if ((substr($this->BUF[$i], ($j + 3), 8)) == "NETSCAPE") {
+                        printf("%s: %s ( %s source )!", $this->VER, $this->ERR['ERR03'], ($i + 1));
+                        exit(0);
+                    }
+                    break;
+                case ";":
+                    $k = false;
+                    break;
                 }
             }
         }
@@ -201,7 +207,7 @@ class GIFEncode
      */
     public function GIFAddFrames($i, $d)
     {
-        $Locals_img='';
+        $Locals_img = '';
         $Locals_str = 13 + 3 * (2 << (ord($this->BUF[$i]{10}) & 0x07));
 
         $Locals_end = strlen($this->BUF[$i]) - $Locals_str - 1;
@@ -211,12 +217,12 @@ class GIFEncode
         $Locals_len = 2 << (ord($this->BUF[$i]{10}) & 0x07);
 
         $Global_rgb = substr($this->BUF[0], 13,
-                             3 * (2 << (ord($this->BUF[0]{10}) & 0x07)));
+            3 * (2 << (ord($this->BUF[0]{10}) & 0x07)));
         $Locals_rgb = substr($this->BUF[$i], 13,
-                             3 * (2 << (ord($this->BUF[$i]{10}) & 0x07)));
+            3 * (2 << (ord($this->BUF[$i]{10}) & 0x07)));
 
         $Locals_ext = "!\xF9\x04" . chr(($this->DIS << 2) + 0) .
-            chr(($d >> 0) & 0xFF) . chr(($d >> 8) & 0xFF) . "\x0\x0";
+        chr(($d >> 0) & 0xFF) . chr(($d >> 8) & 0xFF) . "\x0\x0";
 
         if ($this->COL > -1 && ord($this->BUF[$i]{10}) & 0x80) {
             for ($j = 0; $j < (2 << (ord($this->BUF[$i]{10}) & 0x07)); $j++) {
@@ -226,23 +232,23 @@ class GIFEncode
                     ord($Locals_rgb{3 * $j + 2}) == (($this->COL >> 0) & 0xFF)
                 ) {
                     $Locals_ext = "!\xF9\x04" . chr(($this->DIS << 2) + 1) .
-                        chr(($d >> 0) & 0xFF) . chr(($d >> 8) & 0xFF) . chr($j) . "\x0";
+                    chr(($d >> 0) & 0xFF) . chr(($d >> 8) & 0xFF) . chr($j) . "\x0";
                     break;
                 }
             }
         }
         switch ($Locals_tmp{0}) {
-            case "!":
-                /**
-                 * @var string $Locals_img;
-                 */
-                $Locals_img = substr($Locals_tmp, 8, 10);
-                $Locals_tmp = substr($Locals_tmp, 18, strlen($Locals_tmp) - 18);
-                break;
-            case ",":
-                $Locals_img = substr($Locals_tmp, 0, 10);
-                $Locals_tmp = substr($Locals_tmp, 10, strlen($Locals_tmp) - 10);
-                break;
+        case "!":
+            /**
+             * @var string $Locals_img;
+             */
+            $Locals_img = substr($Locals_tmp, 8, 10);
+            $Locals_tmp = substr($Locals_tmp, 18, strlen($Locals_tmp) - 18);
+            break;
+        case ",":
+            $Locals_img = substr($Locals_tmp, 0, 10);
+            $Locals_tmp = substr($Locals_tmp, 10, strlen($Locals_tmp) - 10);
+            break;
         }
         if (ord($this->BUF[$i]{10}) & 0x80 && $this->IMG > -1) {
             if ($Global_len == $Locals_len) {

--- a/thinkphp/library/org/image/driver/imagick.php
+++ b/thinkphp/library/org/image/driver/imagick.php
@@ -9,7 +9,7 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\image\driver;
+namespace org\image\driver;
 
 use think\Lang;
 
@@ -17,18 +17,21 @@ class Imagick
 {
     /**
      * 图像资源对象
+     *
      * @var resource
      */
     private $im;
 
     /**
-     * 图像信息，包括width,height,type,mime,size
+     * 图像信息，包括 width, height, type, mime, size
+     *
      * @var array
      */
     private $info;
 
     /**
      * 构造方法，可用于打开一张图像
+     *
      * @param string $imgname 图像路径
      */
     public function __construct($imgname = null)
@@ -41,6 +44,7 @@ class Imagick
 
     /**
      * 打开一张图像
+     *
      * @param  string $imgname 图像路径
      */
     public function open($imgname)
@@ -67,6 +71,7 @@ class Imagick
 
     /**
      * 保存图像
+     *
      * @param  string  $imgname   图像保存名称
      * @param  string  $type      图像类型
      * @param  boolean $interlace 是否对JPEG类型图像设置隔行扫描
@@ -104,6 +109,7 @@ class Imagick
 
     /**
      * 返回图像宽度
+     *
      * @return integer 图像宽度
      */
     public function width()
@@ -117,6 +123,7 @@ class Imagick
 
     /**
      * 返回图像高度
+     *
      * @return integer 图像高度
      */
     public function height()
@@ -130,6 +137,7 @@ class Imagick
 
     /**
      * 返回图像类型
+     *
      * @return string 图像类型
      */
     public function type()
@@ -143,6 +151,7 @@ class Imagick
 
     /**
      * 返回图像MIME类型
+     *
      * @return string 图像MIME类型
      */
     public function mime()
@@ -156,6 +165,7 @@ class Imagick
 
     /**
      * 返回图像尺寸数组 0 - 图像宽度，1 - 图像高度
+     *
      * @return array 图像尺寸
      */
     public function size()
@@ -169,6 +179,7 @@ class Imagick
 
     /**
      * 裁剪图像
+     *
      * @param  integer $w      裁剪区域宽度
      * @param  integer $h      裁剪区域高度
      * @param  integer $x      裁剪区域x坐标
@@ -204,7 +215,10 @@ class Imagick
         }
     }
 
-    /* 裁剪图片，内部调用 */
+    /**
+     * 裁剪图片，内部调用
+     *
+     */
     private function _crop($w, $h, $x, $y, $width, $height, $img = null)
     {
         is_null($img) && $img = $this->im;
@@ -228,6 +242,7 @@ class Imagick
 
     /**
      * 生成缩略图
+     *
      * @param  integer $width  缩略图最大宽度
      * @param  integer $height 缩略图最大高度
      * @param  integer $type   缩略图裁剪类型
@@ -364,7 +379,10 @@ class Imagick
         $this->crop($w, $h, $x, $y, $width, $height);
     }
 
-    /* 填充指定图像，内部使用 */
+    /**
+     * 填充指定图像，内部使用
+     *
+     */
     private function _fill($newimg, $posx, $posy, $neww, $newh, $img = null)
     {
         is_null($img) && $img = $this->im;
@@ -381,6 +399,7 @@ class Imagick
 
     /**
      * 添加水印
+     *
      * @param  string  $source 水印图片路径
      * @param  integer $locate 水印位置
      * @param  integer $alpha  水印透明度
@@ -493,6 +512,7 @@ class Imagick
 
     /**
      * 图像添加文字
+     *
      * @param  string  $text   添加的文字
      * @param  string  $font   字体路径
      * @param  integer $size   字号
@@ -633,9 +653,11 @@ class Imagick
 
     /**
      * 析构方法，用于销毁图像资源
+     *
      */
     public function __destruct()
     {
         empty($this->im) || $this->im->destroy();
     }
+
 }

--- a/thinkphp/library/org/oauth.php
+++ b/thinkphp/library/org/oauth.php
@@ -9,7 +9,7 @@
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
 
-namespace think;
+namespace org;
 
 // oauth登录接口
 // <code>

--- a/thinkphp/library/org/oauth/driver.php
+++ b/thinkphp/library/org/oauth/driver.php
@@ -9,7 +9,7 @@
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
 
-namespace think\oauth;
+namespace org\oauth;
 
 abstract class Driver
 {

--- a/thinkphp/library/org/oauth/driver/baidu.php
+++ b/thinkphp/library/org/oauth/driver/baidu.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Baidu extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/diandian.php
+++ b/thinkphp/library/org/oauth/driver/diandian.php
@@ -9,9 +9,9 @@
 // | Author: 杨维杰 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Diandian extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/douban.php
+++ b/thinkphp/library/org/oauth/driver/douban.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Douban extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/github.php
+++ b/thinkphp/library/org/oauth/driver/github.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Github extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/google.php
+++ b/thinkphp/library/org/oauth/driver/google.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Google extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/kaixin.php
+++ b/thinkphp/library/org/oauth/driver/kaixin.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Kaixin extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/msn.php
+++ b/thinkphp/library/org/oauth/driver/msn.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Msn extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/qq.php
+++ b/thinkphp/library/org/oauth/driver/qq.php
@@ -9,9 +9,9 @@
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Qq extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/renren.php
+++ b/thinkphp/library/org/oauth/driver/renren.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Renren extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/sina.php
+++ b/thinkphp/library/org/oauth/driver/sina.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Sina extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/sohu.php
+++ b/thinkphp/library/org/oauth/driver/sohu.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Sohu extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/t163.php
+++ b/thinkphp/library/org/oauth/driver/t163.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class T163 extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/taobao.php
+++ b/thinkphp/library/org/oauth/driver/taobao.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Taobao extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/tencent.php
+++ b/thinkphp/library/org/oauth/driver/tencent.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class Tencent extends Driver
 {

--- a/thinkphp/library/org/oauth/driver/x360.php
+++ b/thinkphp/library/org/oauth/driver/x360.php
@@ -9,9 +9,9 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\oauth\driver;
+namespace org\oauth\driver;
 
-use think\oauth\Driver;
+use org\oauth\Driver;
 
 class X360 extends Driver
 {

--- a/thinkphp/library/org/parser.php
+++ b/thinkphp/library/org/parser.php
@@ -9,7 +9,7 @@
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
 
-namespace think;
+namespace org;
 
 // 内容解析类
 class Parser

--- a/thinkphp/library/org/parser/driver/markdown.php
+++ b/thinkphp/library/org/parser/driver/markdown.php
@@ -13,7 +13,7 @@
 
 # 应用到ThinkPHP中，因而修改为ThinkPHP规范的命名空间
 # namespace Michelf;
-namespace think\parser\driver;
+namespace org\parser\driver;
 
 #
 # The following two constants are deprecated: avoid using them, they'll

--- a/thinkphp/library/org/parser/driver/ubb.php
+++ b/thinkphp/library/org/parser/driver/ubb.php
@@ -11,7 +11,7 @@
 // | Ubb.php 2013-04-03
 // +----------------------------------------------------------------------
 
-namespace think\parser\driver;
+namespace org\parser\driver;
 
 class Ubb
 {

--- a/thinkphp/library/org/transform.php
+++ b/thinkphp/library/org/transform.php
@@ -9,7 +9,7 @@
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
 
-namespace think;
+namespace org;
 
 // 内容解析类
 use think\Exception as Exception;

--- a/thinkphp/library/org/transform/driver/base64.php
+++ b/thinkphp/library/org/transform/driver/base64.php
@@ -1,0 +1,87 @@
+<?php
+// +----------------------------------------------------------------------
+// | TOPThink [ WE CAN DO IT JUST THINK ]
+// +----------------------------------------------------------------------
+// | Copyright (c) 2011 http://topthink.com All rights reserved.
+// +----------------------------------------------------------------------
+// | Licensed ( http://www.apache.org/licenses/LICENSE-2.0 )
+// +----------------------------------------------------------------------
+// | Author: Haotong Lin<lofanmi@gmail.com>
+// +----------------------------------------------------------------------
+
+namespace org\transform\driver;
+
+/**
+ * Base64编码实现
+ * 
+ */
+class Base64
+{
+    /**
+     * @access public
+     * @static 编解码目标
+     *     default: 原始的编(解)码
+     *     url    : URL友好的编(解)码
+     *     regex  : 正则表达式友好的编(解)码
+     */
+    public static $target = 'default';
+
+    /**
+     * Base64编码函数
+     *
+     * @param string $data   欲编码的数据
+     * @param string $target 编码目标
+     */
+    public function encode($data, $target = '')
+    {
+        // 当函数没有特别指定编码目标时, 使用类自身编码目标
+        if (empty($target)) {
+            $target = self::$target;
+        }
+        // 进行一次原始编码
+        $data = base64_encode($data);
+        // 根据编码目标替换字符
+        switch ($target) {
+            case 'url':
+                $data = str_replace(['+', '/', '='], ['-', '_', ''], $data);
+                break;
+            case 'regex':
+                $data = str_replace(['+', '/', '='], ['!', '-', ''], $data);
+                break;
+            case 'default':
+            default:
+                break;
+        }
+        // 返回编码结果
+        return $data;
+    }
+
+    /**
+     * Base64解码函数
+     *
+     * @param string $data   欲解码的数据
+     * @param string $target 解码目标
+     */
+    public function decode($data, $target = '')
+    {
+        // 当函数没有特别指定解码目标时, 使用类自身解码目标
+        if (empty($target)) {
+            $target = self::$target;
+        }
+        // 根据解码目标替换字符
+        switch ($target) {
+            case 'url':
+                $data = str_replace(['-', '_'], ['+', '/'], $data);
+                break;
+            case 'regex':
+                $data = str_replace(['!', '-'], ['+', '/'], $data);
+                break;
+            case 'default':
+            default:
+                break;
+        }
+        // 原始解码，并返回结果
+        return base64_decode($data);
+    }
+
+}

--- a/thinkphp/library/org/transform/driver/json.php
+++ b/thinkphp/library/org/transform/driver/json.php
@@ -9,7 +9,7 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\transform\driver;
+namespace org\transform\driver;
 
 class Json
 {

--- a/thinkphp/library/org/transform/driver/xml.php
+++ b/thinkphp/library/org/transform/driver/xml.php
@@ -9,7 +9,7 @@
 // | Author: 麦当苗儿 <zuojiazi.cn@gmail.com> <http://www.zjzit.cn>
 // +----------------------------------------------------------------------
 
-namespace think\transform\driver;
+namespace org\transform\driver;
 
 class Xml
 {

--- a/thinkphp/library/org/upload.php
+++ b/thinkphp/library/org/upload.php
@@ -9,9 +9,9 @@
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
 
-namespace think;
+namespace org;
 
-use think\Image;
+use org\Image;
 
 class Upload
 {

--- a/thinkphp/library/org/validate.php
+++ b/thinkphp/library/org/validate.php
@@ -9,7 +9,7 @@
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
 
-namespace think;
+namespace org;
 
 use think\Lang;
 


### PR DESCRIPTION
1. thinkphp/library/org/transform/driver/base64.php
很多时候需要进行Base64编码，并在URL中传输，但默认的Base64编码器会把“+”, “/”转换为“%xx”的形式，替换为"-", "_"，正则也是同样意思，不过应用很少。
2. 修正org命名空间，取代之前的think。